### PR TITLE
Bump for lts 12 20

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -7,8 +7,7 @@ main = do
         haddockHoogle       = Flag True,
         haddockHtml         = Flag True,
         haddockProgramArgs  = [("-q",["aliased"])], -- does not seam to do anything
-        haddockExecutables  = Flag True,
-        haddockHscolour     = Flag True
+        haddockExecutables  = Flag True
         }
     }
 

--- a/src/Text/BlazeT/Html.hs
+++ b/src/Text/BlazeT/Html.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE RankNTypes     #-}
 module Text.BlazeT.Html
     (
     module Text.BlazeT
@@ -12,16 +13,16 @@ module Text.BlazeT.Html
     , preEscapedToHtml
     ) where
 
-import Text.BlazeT
+import           Text.BlazeT
 
 type HtmlT = MarkupT
 type HtmlM a = MarkupM a
 type Html = Markup
 
-toHtml ::(ToMarkup a) => a -> Html
+toHtml :: (ToMarkup a) => a -> Html
 toHtml = toMarkup
 
-preEscapedToHtml ::(ToMarkup a) => a -> Html
+preEscapedToHtml :: (ToMarkup a) => a -> Html
 preEscapedToHtml = preEscapedToMarkup
 
 -- $descr1 The following is an adaptation of all "Text.Blaze.Html"

--- a/src/Text/BlazeT/Internal.hs
+++ b/src/Text/BlazeT/Internal.hs
@@ -188,13 +188,17 @@ wrapMarkup2 :: (Text.Blaze.Markup -> Text.Blaze.Markup) -> Markup2
 wrapMarkup2 = wrapMarkupT2
 {-# INLINE wrapMarkup2 #-}
 
+#if MIN_VERSION_base(4,11,0)
+instance (Monad m,Monoid a) => Semigroup (MarkupT m a) where
+  a <> b = do {a' <- a; b >>= return . (mappend a')}
+  {-# INLINE (<>) #-}
+#endif
 
-instance (Monad m,Monoid a) => Monoid (MarkupT m a) where
+instance (Functor m, Monad m,Monoid a) => Monoid (MarkupT m a) where
   mempty = return mempty
-  {-# INLINE mempty #-}
-  a `mappend` b = do {a' <- a; b >>= return . (mappend a')}
+  a `mappend` b = do {a' <- a; fmap (mappend a') b}
   {-# INLINE mappend #-}
-
+  {-# INLINE mempty #-}
 
 instance Monad m => Text.Blaze.Attributable (MarkupT m a) where
   h ! a = wrapMarkupT2 (Text.Blaze.! a) h

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-7.15
+resolver: lts-12.20
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
The latest version of this library is 2 years old, and it breaks with the latest LTS. This PR bumps to the latest LTS, fixing:

- Issue with the `Setup.hs`, please advice if you're ok with drpoping the `haddockHscolour` flag.
- The fact that every Monoid must now be a Semigroup. 
- A warning on the `ToMarkup` instances.

I tried to preserve compatibility with previous versions, as per Travis' current config. Tell me if there's anything else I can do to help this PR deemed mergeable.