### PR TITLE
Update for Cabal >= 2.2 and `base` >= 4.11

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 import Distribution.Simple
 import Distribution.Simple.Setup
 import Distribution.Simple.Haddock
@@ -8,7 +9,16 @@ main = do
         haddockHtml         = Flag True,
         haddockProgramArgs  = [("-q",["aliased"])], -- does not seam to do anything
         haddockExecutables  = Flag True,
+#   if defined(MIN_VERSION_Cabal)
+#     if MIN_VERSION_Cabal(2, 2, 0)
+        haddockLinkedSource = Flag True
+#     else
         haddockHscolour     = Flag True
+#     endif
+#   else
+        -- Almost certainly Cabal 1.22 or older
+        haddockHscolour     = Flag True
+#   endif
         }
     }
 

--- a/src/Text/BlazeT/Html.hs
+++ b/src/Text/BlazeT/Html.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE RankNTypes #-}
 module Text.BlazeT.Html
     (


### PR DESCRIPTION
This fixes #2, which is `Setup.hs` not working for Cabal > 2.0.1.1, and an issue without a ticket, which is `base` >= 4.11 breaking the Monoid instance.

I have not tested anything except compilation with Cabal 3.10.1.0 and `base` 4.17.2.0 (GHC 9.4.7). It should also work on `base` 4.18/GHC 9.6, and I've tried to maintain backward-compatibility with older Cabal/GHC/`base` versions, too.

While I didn't test compilation with older versions, my HLS seemed to be smart enough to pick up on the CPP macros and warn me about, e.g. `mappend` being `(<>)` (or vice versa, I forget) only on the older version when I copy-pasted a small piece of code. That same chunk of code didn't have the warning on the #ifdef pertaining to the version I had installed. That was pretty cool.